### PR TITLE
Slight massaging of the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROGRAM := tiny-lisp
 OBJECTS := tiny-lisp.o
 
-CFLAGS += -std=c11 -Wall -pedantic
+CFLAGS += -std=gnu11 -Wall -pedantic
 
 PREFIX ?= /usr/local
 


### PR DESCRIPTION
The MAP_ANONYMOUS option is not part of standard C11, it is actually a GNU extension. On GCC (Debian 5.3.1-10) 5.3.1 20160224 and possibly other versions the default makefile will not build.

Sorry for the duplicate pull request. I didn't make a dedicated branch for the previous one so my personal changes made it into the request as well.
